### PR TITLE
Use ftype declaration to upgrade minimal fnrecord when available

### DIFF
--- a/code/typo.asd
+++ b/code/typo.asd
@@ -9,7 +9,8 @@
    "introspect-environment"
    "trivia"
    "trivial-arguments"
-   "trivial-garbage")
+   "trivial-garbage"
+   "trivial-cltl2")
 
   :in-order-to ((test-op (test-op "typo.test-suite")))
 


### PR DESCRIPTION
This is a working prototype. Happy to work on polishing it towards inclusion!

I have trouble running the tests because `lax-typep` fails on floating numbers containing NaN. Is there some floating masks I need to set? Also do we want tests for the functionality in this patch?