### PR TITLE
Incorporate ftype information in lambda-expression-specializer

### DIFF
--- a/code/fndb/function-info.lisp
+++ b/code/fndb/function-info.lisp
@@ -31,16 +31,7 @@
 in a way that incorporates any available FTYPE information."
   (multiple-value-bind (lambda-expression closure-p name)
       (function-lambda-expression function)
-    ;; Ensure the lambda expression is available and well formed.
-    (unless (and (consp lambda-expression)
-                 (eql (first lambda-expression) 'lambda)
-                 (consp (rest lambda-expression))
-                 (listp (second lambda-expression)))
-      (return-from annotated-function-lambda-expression
-        (values lambda-expression closure-p name)))
-    (let ((ftype (function-ftype function))
-          (lambda-list (second lambda-expression))
-          (body (cddr lambda-expression)))
+    (let ((ftype (function-ftype function)))
       ;; Ensure an ftype is available.
       (unless (and (consp ftype)
                    (eql (first ftype) 'function)
@@ -48,18 +39,39 @@ in a way that incorporates any available FTYPE information."
                    (listp (second ftype)))
         (return-from annotated-function-lambda-expression
           (values lambda-expression closure-p name)))
-      ;; Create the annotated lambda expression.
-      (multiple-value-bind (body declarations)
-          (alexandria:parse-body body)
-        (multiple-value-bind (ftype-declarations values-type)
-            (ftype-declarations-and-values-type ftype lambda-list)
-          (values
-           `(lambda ,lambda-list
-              ,@ftype-declarations
-              ,@declarations
-              (the ,values-type (progn ,@body)))
-           closure-p
-           name))))))
+      ;; Ensure the lambda expression is available and well formed.
+      (if (and (consp lambda-expression)
+               (eql (first lambda-expression) 'lambda)
+               (consp (rest lambda-expression))
+               (listp (second lambda-expression)))
+          ;; Create the annotated lambda expression.
+          (let ((lambda-list (second lambda-expression))
+                (body (cddr lambda-expression)))
+            (multiple-value-bind (body declarations)
+                (alexandria:parse-body body)
+              (multiple-value-bind (ftype-declarations values-type)
+                  (ftype-declarations-and-values-type ftype lambda-list)
+                (values
+                 `(lambda ,lambda-list
+                    ,@ftype-declarations
+                    ,@declarations
+                    (the ,values-type (progn ,@body)))
+                 closure-p
+                 name))))
+          ;; Lambda expression is not available, create a dummy lambda
+          ;; expression that captures ftype information.
+
+          ;; FIXME: handle the case where `function-lambda-list' is not
+          ;; available either
+          (let ((lambda-list (function-lambda-list function)))
+            (multiple-value-bind (ftype-declarations values-type)
+                (ftype-declarations-and-values-type ftype lambda-list)
+              (values
+               `(lambda ,lambda-list
+                  ,@ftype-declarations
+                  (the ,values-type %anything%))
+               closure-p
+               name)))))))
 
 (defun ftype-declarations-and-values-type (ftype lambda-list)
   (multiple-value-bind (treq topt trest tkey taok tkeyp tvalues)
@@ -115,7 +127,56 @@ in a way that incorporates any available FTYPE information."
 6. A boolean indicating the presence of &key
 
 7. A values type specifier describing the result of the function."
-  (break "TODO"))
+  ;; The following code is adapted from alexandria:parse-ordinary-lambda-list.
+  ;; Assumes ARG-TYPESPEC is a compound function type specifier, as checked by
+  ;; `ftype-declarations-and-values-type'.
+  (let ((state :required)
+        (allow-other-keys nil)
+        (required nil)
+        (optional nil)
+        (rest nil)
+        (keys nil)
+        (keyp nil))
+    (labels ((fail (elt)
+               (error "Misplaced ~S in ftype:~%  ~S" elt arg-typespec)))
+      (dolist (elt (cadr arg-typespec))
+        (case elt
+          (&optional
+           (if (eq state :required)
+               (setf state elt)
+               (fail elt)))
+          (&rest
+           (if (member state '(:required &optional))
+               (setf state elt)
+               (fail elt)))
+          (&key
+           (if (member state '(:required &optional :after-rest))
+               (setf state elt)
+               (fail elt)))
+          (&allow-other-keys
+           (if (eq state '&key)
+               (setf allow-other-keys t
+                     state elt)
+               (fail elt)))
+          (otherwise
+           (case state
+             (:required
+              (push elt required))
+             (&optional
+              (push elt optional))
+             (&rest
+              (setf rest elt
+                    state :after-rest))
+             (&key
+              (push elt keys))
+             (t
+              (error "Invalid ftype:~%  ~S" arg-typespec)))))))
+    (let ((result-types (or (caddr arg-typespec) '(values &rest t))))
+      ;; Normalize result-types
+      (unless (and (consp result-types) (eq (car result-types) 'values))
+        (setq result-types `(values ,result-types &rest t)))
+      (values (nreverse required) (nreverse optional) rest (nreverse keys)
+              allow-other-keys keyp result-types))))
 
 (defun lambda-list-arity (lambda-list)
   "Return two values:

--- a/code/ntype/values-ntype.lisp
+++ b/code/ntype/values-ntype.lisp
@@ -284,6 +284,12 @@ VALUES-NTYPE, or NIL, if there are no rest values."))
     (_
      (error "Not a valid values type specifier: ~S" type-specifier))))
 
+(defun type-specifier-values-ntype (type-specifier)
+  (if (and (consp type-specifier) (eq (car type-specifier) 'values))
+      (values-type-specifier-values-ntype type-specifier)
+      (make-single-value-values-ntype
+       (type-specifier-ntype type-specifier))))
+
 (define-compiler-macro values-type-specifier-values-ntype (&whole whole type-specifier)
   (if (not (constantp type-specifier))
       whole

--- a/code/packages.lisp
+++ b/code/packages.lisp
@@ -75,6 +75,7 @@
      #:values-ntype-type-specifier
      #:values-ntype-union
      #:values-type-specifier-values-ntype
+     #:type-specifier-values-ntype
      #:make-values-ntype
      #:make-single-value-values-ntype)
     ;; The Function Database


### PR DESCRIPTION
This version works good enough in the sense that it:
1. use ftype information fully if available
2. reproduce the behavior of previous version when there is no ftype/`the`

Future work:
1. make ftype/`the` work together with the rest by computing type intersection when processing `the` form. I haven't figure this out yet -- there isn't a `values-ntype-intersection`. I think the current solution work good enough in practice -- when programmer writes `the`, the information is usually precise enough.
2. make use of ftype and function-lambda-expression of other functions called inside the function being specialized