### PR TITLE
handle quote in lambda-expression-specializer

### DIFF
--- a/code/fndb/lambda-expression-specializer.lisp
+++ b/code/fndb/lambda-expression-specializer.lisp
@@ -247,6 +247,10 @@
                           collect (cons symbol (wrapper-nth-value n values-wrapper)))
                     env)))
                 (give-up)))
+           ((quote)
+            (if (= 1 (length rest))
+                (wrap-constant (car rest))
+                (give-up)))
            (otherwise
             (cond
               ;; macros


### PR DESCRIPTION
Once this is incorporated, `typep` and more excitingly `typecase` can be inferred!

```
CL-USER> (defun test (x)
           (etypecase x
             (double-float x)
             (single-float x)))
CL-USER> (petalisp:lazy #'test (petalisp:lazy-array (make-array 3 :element-type 'double-float)))
#<PETALISP-1.0:LAZY-ARRAY DOUBLE-FLOAT (PETALISP-1.0:~ 3)>
```

In practice, it's very useful to e.g. call different CFFI functions in typecase branches.